### PR TITLE
feat: enhance max_supply logic for Jetton supply management

### DIFF
--- a/contracts/jetton/master.tact
+++ b/contracts/jetton/master.tact
@@ -71,7 +71,12 @@ contract JettonMaster with TEP74JettonMaster, TEP89JettonDiscoverable, Deployabl
         nativeThrowUnless(ERROR_CODE_INVALID_AMOUNT, msg.amount > 0); // Reject mint with amount <= 0
         self.requireOwner();
 
-        nativeThrowIf(ERROR_MAX_SUPPLY_EXCEEDED, (self.current_supply + msg.amount) > self.max_supply);
+        // Ensure the new supply does not exceed the max supply
+        // Only for the case that max_supply is not set to unlimited (0)
+        if(self.max_supply > 0){
+            nativeThrowIf(ERROR_MAX_SUPPLY_EXCEEDED, (self.current_supply + msg.amount) > self.max_supply);
+        }
+
         let init = self.discover_wallet_state_init(myAddress(), msg.destination);
         let to = contractAddress(init);
         send(SendParameters{

--- a/contracts/jetton/master.tact
+++ b/contracts/jetton/master.tact
@@ -55,9 +55,6 @@ contract JettonMaster with TEP74JettonMaster, TEP89JettonDiscoverable, Deployabl
         if (msg.key == "max_supply") {
             //Cannot set max supply to 0 through this method
             let new_max_supply = msg.value.loadCoins();
-            nativeThrowIf(ERROR_CODE_INVALID_AMOUNT, new_max_supply <= 0);
-
-            // Ensure the new max supply is greater than the current max supply
             nativeThrowIf(ERROR_CODE_INVALID_AMOUNT, new_max_supply <= self.max_supply);
 
             self.max_supply = new_max_supply;

--- a/contracts/jetton/master.tact
+++ b/contracts/jetton/master.tact
@@ -9,7 +9,7 @@ import "../errors.tact";
 @interface("org.ton.jetton.master")
 contract JettonMaster with TEP74JettonMaster, TEP89JettonDiscoverable, Deployable, OwnableTransferable {
     // Maximum tokens can be minted
-    max_supply: Int = ton("21000000");
+    max_supply: Int = 0;
     // Current tokens minted
     current_supply: Int = 0;
     // Administrator of token. Who can mint new tokens
@@ -22,6 +22,7 @@ contract JettonMaster with TEP74JettonMaster, TEP89JettonDiscoverable, Deployabl
     metadata: OnchainMetadata;
     // Is token initialized (to avoid double init)
     deployed: Bool = false;
+    
     init(owner: Address){
         self.owner = owner;
         let init = initOf JettonWallet(myAddress(), myAddress());
@@ -42,7 +43,7 @@ contract JettonMaster with TEP74JettonMaster, TEP89JettonDiscoverable, Deployabl
         self.metadata.set("name", msg.jetton_name);
         self.metadata.set("description", msg.jetton_description);
         self.metadata.set("symbol", msg.jetton_symbol);
-        self.max_supply = msg.max_supply;
+        self.max_supply = msg.max_supply > 0 ? msg.max_supply : 0;
         self.notify(JettonInitOk{query_id: msg.query_id}.toCell());
         self.deployed = true;
     }
@@ -52,7 +53,14 @@ contract JettonMaster with TEP74JettonMaster, TEP89JettonDiscoverable, Deployabl
         
         // Update max supply
         if (msg.key == "max_supply") {
-            self.max_supply = msg.value.loadCoins();
+            //Cannot set max supply to 0 through this method
+            let new_max_supply = msg.value.loadCoins();
+            nativeThrowIf(ERROR_CODE_INVALID_AMOUNT, new_max_supply <= 0);
+
+            // Ensure the new max supply is greater than the current max supply
+            nativeThrowIf(ERROR_CODE_INVALID_AMOUNT, new_max_supply <= self.max_supply);
+
+            self.max_supply = new_max_supply;
             return;
         }
         

--- a/tests/JettonMaster.spec.ts
+++ b/tests/JettonMaster.spec.ts
@@ -299,14 +299,15 @@ describe('JettonMaster', () => {
         expect(maxSupplyUpdateResult.transactions).toHaveTransaction({
             from: deployer.address,
             to: jettonMaster.address,
-            success: true,
+            success: false,
             deploy: false,
             op: OP_CODES.JettonSetParameter,
+            exitCode: 6905
         });
 
         // Checks
         let jettonMasterMetadata = await jettonMaster.getGetJettonData();
-        expect(jettonMasterMetadata.mintable).toEqual(false); 
+        expect(jettonMasterMetadata.mintable).toEqual(true); 
 
         let jettonContent = jettonMasterMetadata.jetton_content.beginParse();
         expect(jettonContent.loadUint(8)).toEqual(0);

--- a/tests/MaxSupply.spec.ts
+++ b/tests/MaxSupply.spec.ts
@@ -1,0 +1,341 @@
+import { Blockchain, SandboxContract, TreasuryContract } from '@ton/sandbox';
+import { beginCell, Builder, Cell, Dictionary, toNano } from '@ton/core';
+import { JettonWallet } from '../build/Jetton/tact_JettonWallet';
+import { JettonMaster } from '../build/Jetton/tact_JettonMaster';
+import { OP_CODES } from './constants/opCodes';
+
+import '@ton/test-utils';
+
+const SYSTEM_CELL = Cell.fromBase64('te6cckECIgEAB90AAQHAAQEFoB1rAgEU/wD0pBP0vPLICwMCAWIEFwN60AHQ0wMBcbCjAfpAASDXSYEBC7ry4Igg1wsKIIEE/7ry0ImDCbry4IhUUFMDbwT4YQL4Yts8VRTbPPLgghwFFgP2AY5XgCDXIXAh10nCH5UwINcLH94gghAXjUUZuo4YMNMfAYIQF41FGbry4IHTP/oAWWwSMaB/4IIQe92X3rqOF9MfAYIQe92X3rry4IHTP/oAWWwSMaB/4DB/4HAh10nCH5UwINcLH94gghAPin6luo8IMNs8bBfbPH/gBgcKAMbTHwGCEA+KfqW68uCB0z/6APpAASDXSYEBC7ry4Igg1wsKIIEE/7ry0ImDCbry4IgB+kABINdJgQELuvLgiCDXCwoggQT/uvLQiYMJuvLgiAHSAAGR1JJtAeL6AFFmFhUUQzAEkjKBGvklwgDy9PhBbyQQThA9TLrbPCihgRr1IcL/8vRUHcuBGvYM2zyqAIIJMS0AoIIImJaAoC2gUAq5GPL0UgZeNBA6SRjbPFwREg0IAtZwWchwAcsBcwHLAXABywASzMzJ+QDIcgHLAXABywASygfL/8nQINdJgQELuvLgiCDXCwoggQT/uvLQiYMJuvLgiFCYcIBAfylPEwEREAEOyFVQ2zzJEGcQWRBKEDtBgBA2EDUQNFnbPDBDRAkUAKqCEBeNRRlQB8sfFcs/UAP6AgEg10mBAQu68uCIINcLCiCBBP+68tCJgwm68uCIzxYBINdJgQELuvLgiCDXCwoggQT/uvLQiYMJuvLgiM8WAfoCAc8WA8AgghAXjUUZuo8IMNs8bBbbPH/gghBZXwe8uo7B0x8BghBZXwe8uvLggdM/+gD6QAEg10mBAQu68uCIINcLCiCBBP+68tCJgwm68uCIAdIAAZHUkm0B4lUwbBTbPH/gMHALDBAAstMfAYIQF41FGbry4IHTP/oA+kABINdJgQELuvLgiCDXCwoggQT/uvLQiYMJuvLgiAH6QAEg10mBAQu68uCIINcLCiCBBP+68tCJgwm68uCIAfoAUVUVFEMwAvKBGvklwgDy9PhBbyRT4scFs47ZLgUQThA9TL8o2zxwWchwAcsBcwHLAXABywASzMzJ+QDIcgHLAXABywASygfL/8nQINdJgQELuvLgiCDXCwoggQT/uvLQiYMJuvLgiFLQxwXy4IQQThA9TLreUaiggRr1IcL/8vQhDQ4AkshSQMxwAcsAWCDXSYEBC7ry4Igg1wsKIIEE/7ry0ImDCbry4IjPFgEg10mBAQu68uCIINcLCiCBBP+68tCJgwm68uCIzxbJUjAD9oIImJaAoYIImJaAIPgnbxAlobYIoaEmwgCPVSahUEtDMNs8GKFxcChIE1B0yFUwghBzYtCcUAXLHxPLPwH6AgEg10mBAQu68uCIINcLCiCBBP+68tCJgwm68uCIzxYBzxbJKkYUUFUUQzBtbds8MAOWEHtQiV8I4iHCABIUDwFGjp1wcgTIAYIQ1TJ221jLH8s/yRBFQzAVEDRtbds8MJJsMeIUA3owgRr5IsIA8vT4QW8kEEsQOkmH2zyBGvZUG6mCCTEtAArbPBegF7wX8vRRYaGBGvUhwv/y9HB/VBQ3gEALERITABL4QlJAxwXy4IQAZGwx+kABINdJgQELuvLgiCDXCwoggQT/uvLQiYMJuvLgiDD6ADFx1yH6ADH6ADCnA6sAAcbIVTCCEHvdl95QBcsfE8s/AfoCASDXSYEBC7ry4Igg1wsKIIEE/7ry0ImDCbry4IjPFgEg10mBAQu68uCIINcLCiCBBP+68tCJgwm68uCIzxbJJwRDE1CZECQQI21t2zwwVQMUAcrIcQHKAVAHAcoAcAHKAlAFINdJgQELuvLgiCDXCwoggQT/uvLQiYMJuvLgiM8WUAP6AnABymgjbrORf5MkbrPilzMzAXABygDjDSFus5x/AcoAASBu8tCAAcyVMXABygDiyQH7CBUAmH8BygDIcAHKAHABygAkbrOdfwHKAAQgbvLQgFAEzJY0A3ABygDiJG6znX8BygAEIG7y0IBQBMyWNANwAcoA4nABygACfwHKAALJWMwAqsj4QwHMfwHKAFVAUFQg10mBAQu68uCIINcLCiCBBP+68tCJgwm68uCIzxZYINdJgQELuvLgiCDXCwoggQT/uvLQiYMJuvLgiM8WzBLMgQEBzwDJ7VQCASAYIQIBWBkbAhG0o7tnm2eNijAcGgACIwIRt2BbZ5tnjYqQHCABxu1E0NQB+GPSAAGOS/pAASDXSYEBC7ry4Igg1wsKIIEE/7ry0ImDCbry4IgB+kABINdJgQELuvLgiCDXCwoggQT/uvLQiYMJuvLgiAHU1IEBAdcAVUBsFeD4KNcLCoMJuvLgiR0BivpAASDXSYEBC7ry4Igg1wsKIIEE/7ry0ImDCbry4IgB+kABINdJgQELuvLgiCDXCwoggQT/uvLQiYMJuvLgiBIC0QHbPB4BGnAi+ENUEEDbPNDUMFgfANYC0PQEMG0BgQ61AYAQ9A9vofLghwGBDrUiAoAQ9BfIAcj0AMkBzHABygBAA1kg10mBAQu68uCIINcLCiCBBP+68tCJgwm68uCIzxYBINdJgQELuvLgiCDXCwoggQT/uvLQiYMJuvLgiM8WyQAIVHA0JQARvhX3aiaGkAAM3f4AOg==');
+
+const JETTON_NAME = "Test jetton";
+const JETTON_DESCRIPTION = "Test jetton description. Test jetton description. Test jetton description";
+const JETTON_SYMBOL = "TSTJTN";
+const JETTON_MAX_SUPPLY = toNano("0");
+
+describe('MaxSupply - Unlimited', () => {
+    let blockchain: Blockchain;
+    let deployer: SandboxContract<TreasuryContract>;
+    let other: SandboxContract<TreasuryContract>;
+    let jettonMaster: SandboxContract<JettonMaster>;
+    let jettonWallet: SandboxContract<JettonWallet>;
+    let otherJettonWallet: SandboxContract<JettonWallet>;
+
+    beforeEach(async () => {
+        blockchain = await Blockchain.create();
+
+        deployer = await blockchain.treasury('deployer');
+        other = await blockchain.treasury("other");
+
+        jettonMaster = blockchain.openContract(await JettonMaster.fromInit(deployer.address));
+        jettonWallet = blockchain.openContract(await JettonWallet.fromInit(jettonMaster.address, deployer.address));
+        otherJettonWallet = blockchain.openContract(await JettonWallet.fromInit(jettonMaster.address, other.address));
+
+        const deployResult = await jettonMaster.send(
+            deployer.getSender(),
+            {
+                value: toNano("0.05"),
+            },
+            {
+                $$type: 'JettonInit',
+                query_id: 0n,
+                jetton_name: beginCell().storeStringTail(JETTON_NAME).asSlice(),
+                jetton_description: beginCell().storeStringTail(JETTON_DESCRIPTION).asSlice(),
+                jetton_symbol: beginCell().storeStringTail(JETTON_SYMBOL).asSlice(),
+                max_supply: JETTON_MAX_SUPPLY,
+            }
+        );
+        expect(deployResult.transactions).toHaveTransaction({
+            from: deployer.address,
+            to: jettonMaster.address,
+            success: true,
+            deploy: true,
+            op: OP_CODES.JettonInit,
+        });
+        expect(deployResult.transactions).toHaveTransaction({
+            from: jettonMaster.address,
+            to: deployer.address,
+            success: true,
+            deploy: false,
+            op: OP_CODES.JettonInitOk,
+        });
+    });
+
+    
+
+    it('should correct build wallet address', async () => {
+        let walletAddressData = await jettonMaster.getGetWalletAddress(deployer.address);
+        expect(walletAddressData.toString()).toEqual(jettonWallet.address.toString());
+
+        let otherWalletAddressData = await jettonMaster.getGetWalletAddress(other.address);
+        expect(otherWalletAddressData.toString()).toEqual(otherJettonWallet.address.toString());
+    });
+
+
+    it('should not double init', async () => {
+        const deployResult = await jettonMaster.send(
+            deployer.getSender(),
+            {
+                value: toNano("0.05"),
+            },
+            {
+                $$type: 'JettonInit',
+                query_id: 0n,
+                jetton_name: beginCell().storeStringTail(JETTON_NAME).asSlice(),
+                jetton_description: beginCell().storeStringTail(JETTON_DESCRIPTION).asSlice(),
+                jetton_symbol: beginCell().storeStringTail(JETTON_SYMBOL).asSlice(),
+                max_supply: JETTON_MAX_SUPPLY,
+            }
+        );
+
+        expect(deployResult.transactions).toHaveTransaction({
+            from: deployer.address,
+            to: jettonMaster.address,
+            success: false,
+            deploy: false,
+            op: OP_CODES.JettonInit,
+            exitCode: 6903,
+        });
+    });
+
+    it('should mint tokens', async () => {
+
+        // mint tokens with unlimited supply
+        const mintResult = await jettonMaster.send(
+            deployer.getSender(),
+            {
+                value: toNano("0.05"),
+            },
+            {
+                $$type: 'JettonMint',
+                query_id: 0n,
+                amount: toNano("1337"),
+                destination: deployer.address,
+            }
+        );
+        expect(mintResult.transactions).toHaveTransaction({
+            from: deployer.address,
+            to: jettonMaster.address,
+            success: true,
+            deploy: false,
+            op: OP_CODES.JettonMint,
+        });
+        expect(mintResult.transactions).toHaveTransaction({
+            from: jettonMaster.address,
+            to: jettonWallet.address,
+            success: true,
+            deploy: true,
+            op: 0x178d4519,
+        });
+
+        let jettonMasterMetadata = await jettonMaster.getGetJettonData();
+        expect(jettonMasterMetadata.total_supply).toEqual(toNano("1337"));
+
+        let jettonWalletData = await jettonWallet.getGetWalletData();
+        expect(jettonWalletData.balance).toEqual(toNano("1337"));
+    });
+
+
+    it('should fail to set max supply less than the current supply', async () => { 
+        
+          // set max_supply to 1337
+          const maxSupplyUpdateResult = await jettonMaster.send(
+            deployer.getSender(),
+            {
+                value: toNano("0.05"),
+            },
+            {
+                $$type: 'JettonSetParameter',
+                key: "max_supply",
+                value: beginCell().storeCoins(toNano("1337")).asSlice()
+            }
+        );
+            expect(maxSupplyUpdateResult.transactions).toHaveTransaction({
+                from: deployer.address,
+                to: jettonMaster.address,
+                success: true,
+                deploy: false,
+                op: OP_CODES.JettonSetParameter,
+            });
+
+        //mint 1337 tokens
+        const mintResult = await jettonMaster.send(
+            deployer.getSender(),
+            {
+                value: toNano("0.05"),
+            },
+            {
+                $$type: 'JettonMint',
+                query_id: 0n,
+                amount: toNano("1337"),
+                destination: deployer.address,
+            }
+        );
+        expect(mintResult.transactions).toHaveTransaction({
+            from: deployer.address,
+            to: jettonMaster.address,
+            success: true,
+            deploy: false,
+            op: OP_CODES.JettonMint,
+        });
+
+
+        // try to set the max_supply to 1330, less than current supply
+        const maxSupplyUpdateResult2 = await jettonMaster.send(
+            deployer.getSender(),
+            {
+                value: toNano("0.05"),
+            },
+            {
+                $$type: 'JettonSetParameter',
+                key: "max_supply",
+                value: beginCell().storeCoins(toNano("1330")).asSlice()
+            }
+        );
+        expect(maxSupplyUpdateResult2.transactions).toHaveTransaction({
+            from: deployer.address,
+            to: jettonMaster.address,
+            success: false,
+            deploy: false,
+            op: OP_CODES.JettonSetParameter,
+            exitCode: 6905,
+        });
+     
+    });
+
+
+    it('should set max supply and hit the mint limit JettonSetParameter', async () => { 
+        //set max_supply to 100
+        const maxSupplyUpdateResult = await jettonMaster.send(
+            deployer.getSender(),
+            {
+                value: toNano("0.05"),
+            },
+            {
+                $$type: 'JettonSetParameter',
+                key: "max_supply",
+                value: beginCell().storeCoins(toNano("100")).asSlice()
+            }
+        );
+        expect(maxSupplyUpdateResult.transactions).toHaveTransaction({
+            from: deployer.address,
+            to: jettonMaster.address,
+            success: true,
+            deploy: false,
+            op: OP_CODES.JettonSetParameter,
+        });
+
+        //try to mint 100 tokens 
+        const mintResult = await jettonMaster.send(
+            deployer.getSender(),
+            {
+                value: toNano("0.05"),
+            },
+            {
+                $$type: 'JettonMint',
+                query_id: 0n,
+                amount: toNano("100"),
+                destination: deployer.address,
+            }
+        );
+        expect(mintResult.transactions).toHaveTransaction({
+            from: deployer.address,
+            to: jettonMaster.address,
+            success: true,
+            deploy: false,
+            op: OP_CODES.JettonMint,
+        });
+
+        //try to mint 100 tokens more and hit max supply limit
+        const mintResult2 = await jettonMaster.send(
+            deployer.getSender(),
+            {
+                value: toNano("0.05"),
+            },
+            {
+                $$type: 'JettonMint',
+                query_id: 0n,
+                amount: toNano("100"),
+                destination: deployer.address,
+            }
+        );
+        expect(mintResult2.transactions).toHaveTransaction({
+            from: deployer.address,
+            to: jettonMaster.address,
+            success: false,
+            deploy: false,
+            op: OP_CODES.JettonMint,
+            exitCode: 6904,
+        });
+
+
+        //try to set max supply to 10, less than current supply
+        const maxSupplyUpdateResult2 = await jettonMaster.send(
+            deployer.getSender(),
+            {
+                value: toNano("0.05"),
+            },
+            {
+                $$type: 'JettonSetParameter',
+                key: "max_supply",
+                value: beginCell().storeCoins(toNano("10")).asSlice()
+            }
+        );
+        expect(maxSupplyUpdateResult2.transactions).toHaveTransaction({
+            from: deployer.address,
+            to: jettonMaster.address,
+            success: false,
+            deploy: false,
+            op: OP_CODES.JettonSetParameter,
+            exitCode: 6905
+        });
+
+        //set max_supply to 200 
+        const maxSupplyUpdateResult3 = await jettonMaster.send(
+            deployer.getSender(),
+            {
+                value: toNano("0.05"),
+            },
+            {
+                $$type: 'JettonSetParameter',
+                key: "max_supply",
+                value: beginCell().storeCoins(toNano("200")).asSlice()
+            }
+        );
+        expect(maxSupplyUpdateResult3.transactions).toHaveTransaction({
+            from: deployer.address,
+            to: jettonMaster.address,
+            success: true,
+            deploy: false,
+            op: OP_CODES.JettonSetParameter,
+        });
+
+
+        // try to mint 100 tokens more
+        const mintResult3 = await jettonMaster.send(
+            deployer.getSender(),
+            {
+                value: toNano("0.05"),
+            },
+            {
+                $$type: 'JettonMint',
+                query_id: 0n,
+                amount: toNano("100"),
+                destination: deployer.address,
+            }
+        );
+        expect(mintResult3.transactions).toHaveTransaction({
+            from: deployer.address,
+            to: jettonMaster.address,
+            success: true,
+            deploy: false,
+            op: OP_CODES.JettonMint,
+        });     
+    });
+
+    it('should return system cell', async () => {
+        let systemCell = await jettonMaster.getTactSystemCell();
+        expect(systemCell).toEqualCell(SYSTEM_CELL);
+    });
+    
+});

--- a/tests/Ownership.spec.ts
+++ b/tests/Ownership.spec.ts
@@ -11,7 +11,7 @@ const JETTON_SYMBOL = "TSTJTN";
 const JETTON_MAX_SUPPLY = toNano("100500");
 
 
-describe('JettonMaster', () => {
+describe('OwnerShip', () => {
     let blockchain: Blockchain;
     let deployer: SandboxContract<TreasuryContract>;
     let other: SandboxContract<TreasuryContract>;


### PR DESCRIPTION
### PR Summary: Update `max_supply` Attribute in Jetton Implementation

This PR updates the handling of the `max_supply` attribute to improve flexibility and enforce stricter rules.

#### Key Changes:
1. **Optional `max_supply`**:
   - `max_supply` can be `0` to indicate unlimited supply.

2. **Minting Rules**:
   - Minting stops when `max_supply` is reached (if not `0`).
   - Unlimited minting allowed if `max_supply` is `0`.

3. **Update Restrictions**:
   - `max_supply` can only be set to `0` during initialization (`JettonInit`).
   - `max_supply` can only be increased via `JettonSetParameter`.

4. **Tests**:
   - Added basic tests to verify minting behavior and `max_supply` constraints.
