### PR TITLE
feat: add nonce argument to JettonMaster contructor

### DIFF
--- a/contracts/jetton/master.tact
+++ b/contracts/jetton/master.tact
@@ -25,7 +25,7 @@ contract JettonMaster with TEP74JettonMaster, TEP89JettonDiscoverable, Deployabl
     // Is token initialized (to avoid double init)
     deployed: Bool = false;
     
-    init(owner: Address){
+    init(owner: Address, nonce: Int){
         self.owner = owner;
         let init = initOf JettonWallet(myAddress(), myAddress());
         let data = init.data.beginParse();

--- a/scripts/deployJettonMaster.ts
+++ b/scripts/deployJettonMaster.ts
@@ -3,7 +3,7 @@ import { JettonMaster } from '../wrappers/JettonMaster';
 import { NetworkProvider } from '@ton/blueprint';
 
 export async function run(provider: NetworkProvider) {
-    const jettonMaster = provider.open(await JettonMaster.fromInit(provider.sender().address!!));
+    const jettonMaster = provider.open(await JettonMaster.fromInit(provider.sender().address!!, 0n));
 
     await jettonMaster.send(
         provider.sender(),

--- a/tests/JettonMaster.spec.ts
+++ b/tests/JettonMaster.spec.ts
@@ -32,7 +32,7 @@ describe('JettonMaster', () => {
         deployer = await blockchain.treasury('deployer');
         other = await blockchain.treasury("other");
 
-        jettonMaster = blockchain.openContract(await JettonMaster.fromInit(deployer.address));
+        jettonMaster = blockchain.openContract(await JettonMaster.fromInit(deployer.address, 0n));
         jettonWallet = blockchain.openContract(await JettonWallet.fromInit(jettonMaster.address, deployer.address));
         otherJettonWallet = blockchain.openContract(await JettonWallet.fromInit(jettonMaster.address, other.address));
 
@@ -66,6 +66,14 @@ describe('JettonMaster', () => {
         });
     });
 
+    it('should mint multiple jettons per wallet', async () => {
+        const jettonMasterSameNonce = blockchain.openContract(await JettonMaster.fromInit(deployer.address, 0n));;
+        expect(jettonMasterSameNonce.address).toEqualAddress(jettonMaster.address);
+
+        const jettonMasterDiffNonce = blockchain.openContract(await JettonMaster.fromInit(deployer.address, 1n));;
+        expect(jettonMasterDiffNonce.address).not.toEqualAddress(jettonMaster.address);
+    });
+
     it('should handle big strings', async () => {
         const LONG_JETTON_NAME = JETTON_NAME.repeat(100);
         const LONG_JETTON_DESCRIPTION = JETTON_DESCRIPTION.repeat(20);
@@ -75,7 +83,7 @@ describe('JettonMaster', () => {
         expect(LONG_JETTON_DESCRIPTION.length).toBeGreaterThan(1024);
         expect(LONG_JETTON_SYMBOL.length).toBeGreaterThan(1024);
 
-        const otherJettonMaster = blockchain.openContract(await JettonMaster.fromInit(other.address));
+        const otherJettonMaster = blockchain.openContract(await JettonMaster.fromInit(other.address, 0n));
         await otherJettonMaster.send(
             other.getSender(),
             {

--- a/tests/JettonWallet.spec.ts
+++ b/tests/JettonWallet.spec.ts
@@ -24,7 +24,7 @@ describe('JettonMaster', () => {
         deployer = await blockchain.treasury('deployer');
         other = await blockchain.treasury("other");
 
-        jettonMaster = blockchain.openContract(await JettonMaster.fromInit(deployer.address));
+        jettonMaster = blockchain.openContract(await JettonMaster.fromInit(deployer.address, 0n));
         jettonWallet = blockchain.openContract(await JettonWallet.fromInit(jettonMaster.address, deployer.address));
         otherJettonWallet = blockchain.openContract(await JettonWallet.fromInit(jettonMaster.address, other.address));
 

--- a/tests/MaxSupply.spec.ts
+++ b/tests/MaxSupply.spec.ts
@@ -27,7 +27,7 @@ describe('MaxSupply - Unlimited', () => {
         deployer = await blockchain.treasury('deployer');
         other = await blockchain.treasury("other");
 
-        jettonMaster = blockchain.openContract(await JettonMaster.fromInit(deployer.address));
+        jettonMaster = blockchain.openContract(await JettonMaster.fromInit(deployer.address, 0n));
         jettonWallet = blockchain.openContract(await JettonWallet.fromInit(jettonMaster.address, deployer.address));
         otherJettonWallet = blockchain.openContract(await JettonWallet.fromInit(jettonMaster.address, other.address));
 

--- a/tests/Mintable.spec.ts
+++ b/tests/Mintable.spec.ts
@@ -27,7 +27,7 @@ describe('Mintable', () => {
         deployer = await blockchain.treasury('deployer');
         other = await blockchain.treasury("other");
 
-        jettonMaster = blockchain.openContract(await JettonMaster.fromInit(deployer.address));
+        jettonMaster = blockchain.openContract(await JettonMaster.fromInit(deployer.address, 0n));
         jettonWallet = blockchain.openContract(await JettonWallet.fromInit(jettonMaster.address, deployer.address));
         otherJettonWallet = blockchain.openContract(await JettonWallet.fromInit(jettonMaster.address, other.address));
 

--- a/tests/Ownership.spec.ts
+++ b/tests/Ownership.spec.ts
@@ -25,7 +25,7 @@ describe('OwnerShip', () => {
         deployer = await blockchain.treasury('deployer');
         other = await blockchain.treasury("other");
 
-        jettonMaster = blockchain.openContract(await JettonMaster.fromInit(deployer.address));
+        jettonMaster = blockchain.openContract(await JettonMaster.fromInit(deployer.address, 0n));
         jettonWallet = blockchain.openContract(await JettonWallet.fromInit(jettonMaster.address, deployer.address));
         jettonWallet2 = blockchain.openContract(await JettonWallet.fromInit(jettonMaster.address, other.address));
 


### PR DESCRIPTION
**Changes summary**:
Updated initial parameters of this contract to make possible mint multiple jettons using single TON wallet. Second argument was added to contructor. Previously `JettonMaster` constructor takes one argument - owner address. It means that only one jetton could be minted per owner address. Now users will set it random or as current UTC timestamp to avoid contract address collision